### PR TITLE
Update report URL to point to the new couchdb at mozmill-crowd.blargon7.com

### DIFF
--- a/extension/defaults/preferences/mozmill-crowd.js
+++ b/extension/defaults/preferences/mozmill-crowd.js
@@ -4,7 +4,7 @@ pref("extensions.mozmill-crowd.endurance.iterations", 1);
 pref("extensions.mozmill-crowd.endurance.restart", true);
 pref("extensions.mozmill-crowd.firstrun", true);
 pref("extensions.mozmill-crowd.report.send", false);
-pref("extensions.mozmill-crowd.report.server", "http://mozmill-crowd.brasstacks.mozilla.com/db/");
+pref("extensions.mozmill-crowd.report.server", "http://mozmill-crowd.blargon7.com/db/");
 pref("extensions.mozmill-crowd.repositories.mozmill-tests", "https://hg.mozilla.org/qa/mozmill-tests/");
 pref("extensions.mozmill-crowd.repositories.mozmill-tests.custom", false);
 pref("extensions.mozmill-crowd.repositories.mozmill-automation", "https://hg.mozilla.org/qa/mozmill-automation/");


### PR DESCRIPTION
This will let our users report to the new couchdb instance. 
