### PR TITLE
Make extension work with latest Firefox release #11

### DIFF
--- a/extension/chrome/content/download.js
+++ b/extension/chrome/content/download.js
@@ -94,7 +94,7 @@ Downloader = {
 
       // Save URL as target
       this._persist.progressListener = new DownloaderListener();
-      this._persist.saveURI(uri, null, null, null, null, this.target);
+      this._persist.saveURI(uri, null, null, null, null, this.target, null);
     }
     catch (ex) {
       window.alert(ex);

--- a/extension/chrome/locale/en-US/mozmill-crowd.properties
+++ b/extension/chrome/locale/en-US/mozmill-crowd.properties
@@ -2,6 +2,7 @@ application.invalid="%1$S" is not a valid Firefox application.
 
 execution.user_abort=The operation was aborted at user request.
 
+storage.select_storage=Please select a directory for storage
 storage.log_not_found=The log file "%1$S" could not be read.
 storage.path_not_found=Mozmill Crowd requires a location on the hard disk to prepare the test environment, storing of tests and results. Please select or create a folder.
 storage.path_has_space=Due to limitations, we currently do not support folders with a space in the path. Please select a new one.

--- a/extension/defaults/preferences/mozmill-crowd.js
+++ b/extension/defaults/preferences/mozmill-crowd.js
@@ -7,5 +7,4 @@ pref("extensions.mozmill-crowd.report.send", false);
 pref("extensions.mozmill-crowd.report.server", "http://mozmill-crowd.blargon7.com/db/");
 pref("extensions.mozmill-crowd.repositories.mozmill-tests", "https://hg.mozilla.org/qa/mozmill-tests/");
 pref("extensions.mozmill-crowd.repositories.mozmill-tests.custom", false);
-pref("extensions.mozmill-crowd.repositories.mozmill-automation", "https://hg.mozilla.org/qa/mozmill-automation/");
 pref("extensions.mozmill-crowd.trust_unsecure_addons", false);

--- a/extension/resource/application.js
+++ b/extension/resource/application.js
@@ -132,9 +132,6 @@ Application.prototype = {
    * @returns Path of the application
    */
   currentAppBinary: function Application_currentAppBinary() {
-    var binary = this._dirSrv.get("CurProcD", Ci.nsIFile);
-    binary.append(BINARIES[this.XULRuntime.OS]);
-
-    return binary;
+    return this._dirSrv.get("XREExeF", Ci.nsIFile);
   }
 }

--- a/extension/resource/storage.js
+++ b/extension/resource/storage.js
@@ -51,9 +51,9 @@ var Utils = { }; Cu.import('resource://mozmill-crowd/utils.js', Utils);
 // XXX: For now lets use constants. Has to be moved out to a web service which
 // will return the latest package and the hash
 const ENVIRONMENT_DATA = {
-  Darwin : { url : "https://mozqa.com/mozmill-env/mac-latest.zip" },
-  Linux :  { url : "https://mozqa.com/mozmill-env/linux-latest.zip" },
-  WINNT :  { url : "https://mozqa.com/mozmill-env/windows-latest.zip" }
+  Darwin : { url : "https://mozqa.com/mozmill-env/latest-mac.zip" },
+  Linux :  { url : "https://mozqa.com/mozmill-env/latest-linux.zip" },
+  WINNT :  { url : "https://mozqa.com/mozmill-env/latest-windows.zip" }
 };
 
 // XXX: Has to be removed once we use the PHP script to download the environment
@@ -111,16 +111,6 @@ Storage.prototype = {
       this._createEnvironment();
 
     return this._environment;
-  },
-
-  /**
-   *
-   */
-  get screenshotPath() {
-    var path = this.dir.clone();
-    path.append("screenshots");
-
-    return path;
   },
 
   /**


### PR DESCRIPTION
This is for issue #11 and issue #10.
I had to : 
- change the path of the current process executable in currentAppBinary
- added the new extra parameter in saveURI method 
- dropped the downloading and using of mozmill-automation, instead use the environment commands instead of python scripts(./testrun_functional.py / testrun_functional) 
- also we don't have a latest-environment anymore so I added the mozmill-env 2.0.6 until we can find something else here.  
