### PR TITLE
Replace deprecated nsIWebBrowserPersist.saveURI whit Downloads.createDownload when downloading the mozmill-environment

### DIFF
--- a/extension/chrome/content/download.js
+++ b/extension/chrome/content/download.js
@@ -40,7 +40,7 @@ var Cu = Components.utils;
 
 Cu.import("resource://gre/modules/Downloads.jsm");
 
-const MEGABYTE = 1048576;
+const MEGABYTE_TO_BYTE = 1048576;
 
 Downloader = {
   _persist : null,
@@ -94,17 +94,15 @@ Downloader = {
         var maxMB = 0;
         var currentMB = 0;
 
-        // The download final size and progress percentage is unknown.
-        Downloader.progressMeter.mode =  "undetermined";
-
         aDownload.onchange = function () {
           if (aDownload.hasProgress) {
             if (!maxMB) {
-              maxMB = aDownload.totalBytes / MEGABYTE;
+              maxMB = aDownload.totalBytes / MEGABYTE_TO_BYTE;
+              Downloader.progressMeter.mode =  "determined";
               Downloader.progressMeter.max = maxMB;
             }
 
-            currentMB = aDownload.currentBytes / MEGABYTE;
+            currentMB = aDownload.currentBytes / MEGABYTE_TO_BYTE;
             var string = Downloader.stringBundle.getFormattedString("download.progress",
                                                                     [currentMB.toFixed(2),
                                                                      maxMB.toFixed(2)]);
@@ -114,6 +112,7 @@ Downloader = {
             Downloader.progressMeter.value = currentMB;
           }
         };
+
         aDownload.start();
         aDownload.whenSucceeded().then(() => {
            Downloader.progressLabel.value = Downloader.stringBundle

--- a/extension/chrome/content/download.js
+++ b/extension/chrome/content/download.js
@@ -36,7 +36,9 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
+var Cu = Components.utils;
 
+Cu.import("resource://gre/modules/Downloads.jsm");
 
 Downloader = {
   _persist : null,
@@ -83,18 +85,38 @@ Downloader = {
 
       // If target doesn't exist, create it
       if (!this.target.exists()) {
-        this.target.create(0x00, 0644);
+        this.target.create(Ci.nsIFile.NORMAL_FILE_TYPE, parseInt("0666", 8));
       }
 
-      this._persist = Cc["@mozilla.org/embedding/browser/nsWebBrowserPersist;1"].
-                      createInstance(Ci.nsIWebBrowserPersist);
-      this._persist.persistFlags = Ci.nsIWebBrowserPersist.PERSIST_FLAGS_REPLACE_EXISTING_FILES |
-                                   Ci.nsIWebBrowserPersist.PERSIST_FLAGS_FROM_CACHE |
-                                   Ci.nsIWebBrowserPersist.PERSIST_FLAGS_CLEANUP_ON_FAILURE;
+      Downloads.createDownload({'source': uri, 'target': this.target}).then((aDownload) => {
+        var maxMB = -1;
+        var currentMB = -1;
+        aDownload.onchange = function () {
+          if (aDownload.succeeded) {
+            var bytes = aDownload.hasProgress ?
+                        aDownload.totalBytes : aDownload.currentBytes;
+            maxMB = bytes / 1024 / 1024;
+          } else if (aDownload.hasProgress) {
+            // If the final size and progress are known, use them.
+            maxMB = aDownload.totalBytes / 1024 / 1024;
+            currentMB = aDownload.currentBytes / 1024 / 1024;
+          } else {
+            // The download final size and progress percentage is unknown.
+            Downloader.progressMeter.mode =  "undetermined";
+          }
+            var string = Downloader.stringBundle.getFormattedString("download.progress", [currentMB, maxMB]);
+            Downloader.progressLabel.value = string;
 
-      // Save URL as target
-      this._persist.progressListener = new DownloaderListener();
-      this._persist.saveURI(uri, null, null, null, null, this.target, null);
+            // Update progress meter values
+            Downloader.progressMeter.max = maxMB;
+            Downloader.progressMeter.value = currentMB;
+        };
+        aDownload.start();
+        aDownload.whenSucceeded().then(() => {
+           Downloader.progressLabel.value = Downloader.stringBundle.getString("download.finished");
+           Downloader.stop();
+        });
+      });
     }
     catch (ex) {
       window.alert(ex);
@@ -111,55 +133,3 @@ Downloader = {
     }, 500);
   }
 };
-
-
-function DownloaderListener() {
-}
-
-DownloaderListener.prototype = {
-
-  QueryInterface : function(aIID) {
-    if (aIID.equals(Components.interfaces.nsIWebProgressListener) ||
-        aIID.equals(Components.interfaces.nsISupportsWeakReference) ||
-        aIID.equals(Components.interfaces.nsISupports))
-      return this;
-    throw Components.results.NS_NOINTERFACE;
-  },
-
-  onStateChange : function(aWebProgress, aRequest, aStateFlags, aStatus) {
-    if (aStateFlags & Ci.nsIWebProgressListener.STATE_STOP) {
-      Downloader.progressLabel.value = Downloader.stringBundle.getString("download.finished");
-      Downloader.stop();
-    }
-  },
-
-  onProgressChange : function(aWebProgress, aRequest,
-                              aCurSelfProgress, aMaxSelfProgress,
-                              aCurTotalProgress, aMaxTotalProgress) {
-
-    // If the content size is not known switch to the undetermined display
-    if (aMaxSelfProgress == -1)
-      Downloader.progressMeter.mode =  "undetermined";
-
-    // Update the label
-    var curMB = aCurSelfProgress / 1024 / 1024;
-    var maxMB = aMaxSelfProgress / 1024 / 1024;
-    var string = Downloader.stringBundle.getFormattedString("download.progress",
-                                                            [curMB.toFixed(2),
-                                                             maxMB.toFixed(2)]);
-    Downloader.progressLabel.value = string;
-
-    // Update progress meter values
-    Downloader.progressMeter.max = aMaxSelfProgress;
-    Downloader.progressMeter.value = aCurSelfProgress;
-  },
-
-  onLocationChange : function(aWebProgress, aRequest, aLocation) {
-  },
-
-  onStatusChange : function(aWebProgress, aRequest, aStatus, aMessage) {
-  },
-
-  onSecurityChange : function(aWebProgress, aRequest, aState) {
-  }
-}

--- a/extension/chrome/content/download.xul
+++ b/extension/chrome/content/download.xul
@@ -59,7 +59,7 @@
   <label id="download-progress-label"
          control="download-progress"/>
   <progressmeter id="download-progress"
-                 mode="determined"
+                 mode="undetermined"
                  style="&downloadProgress.width;"/>
 
 </dialog>

--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -12,6 +12,7 @@
     <em:contributor>Henrik Skupin (http://www.hskupin.info)</em:contributor>
     <em:contributor>Aaron Train (http://www.aaronmt.com)</em:contributor>
     <em:contributor>Dave Hunt (http://www.blargon7.com)</em:contributor>
+    <em:contributor>Cosmin Malutan</em:contributor>
     <em:homepageURL>https://wiki.mozilla.org/QA/Mozmill_Test_Automation/Crowd_Testing</em:homepageURL>
     <em:description>Mozmill tests executed from the crowd</em:description>
     <em:aboutURL>chrome://mozmill-crowd/content/about.xul</em:aboutURL>
@@ -24,7 +25,7 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>3.6</em:minVersion>
+        <em:minVersion>26.0</em:minVersion>
         <em:maxVersion>31.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>


### PR DESCRIPTION
This is for issue #22 
As the summary says, I replaced the deprecated nsIWebBrowserPersist.saveURI with Downloads.fetch.
The documentation for Downloads.createDownload module: [Downloads.createDownload](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Downloads.jsm#createDownload())
The documentation for Download class: [Download](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Downloads.jsm/Download)